### PR TITLE
Natefixes

### DIFF
--- a/Sockets/Include/Internal/WebsocketUtils.h
+++ b/Sockets/Include/Internal/WebsocketUtils.h
@@ -31,6 +31,19 @@ namespace Internal {
         static std::string getRequestKey(RFC2616::RequestMessage request);
         static std::string getResponseKey(RFC2616::ResponseMessage response);
         
+        static uint16_t changeEndianness16(uint16_t val){ 
+            return (val << 8) | ((val >> 8) & 0x00ff); 
+        } 
+        static uint64_t changeEndianness64(unsigned long long int val){ 
+            return (val << 56) | 
+                    ((val << 40) & 0x00ff000000000000) | 
+                    ((val << 24) & 0x0000ff0000000000) | 
+                    ((val << 8) & 0x000000ff00000000) | 
+                    ((val >> 8) & 0x00000000ff000000) | 
+                    ((val >> 24) & 0x0000000000ff0000) | 
+                    ((val >> 40) & 0x000000000000ff00) | 
+                    ((val >> 56) & 0x00000000000000ff); 
+        } 
     public:
         static std::string SYN(std::iostream&, URI, std::mt19937);
         static std::string SYNACK(std::iostream&);

--- a/Sockets/Source/Internal/WebsocketUtils.cpp
+++ b/Sockets/Source/Internal/WebsocketUtils.cpp
@@ -179,8 +179,19 @@ bool WebsocketUtils::writeHeader(std::ostream& stream,
     auto size = 0;
     if(preLength == 126) size = 2;
     else if(preLength == 127) size = 8;
-    if(size > 0 && !(stream.write((const char*)&header.length,size)))
-        return false;
+    if(size > 0) { 
+         const char* s; 
+         if (size == 2){ 
+            uint16_t s16 = changeEndianness16((uint16_t)header.length); 
+            s = (const char*)&s16; 
+         } 
+         else{ 
+             uint16_t s64 = changeEndianness64(header.length); 
+             s = (const char*)&s64; 
+         } 
+         if (!(stream.write(s,size))) 
+                return false; 
+     } 
     
     if(header.masked) {
         for(int i = 0; i < 4; i++) {

--- a/Sockets/Source/RFC/StringCodec.cpp
+++ b/Sockets/Source/RFC/StringCodec.cpp
@@ -78,7 +78,7 @@ bool StringCodec::encodeUTF8(const unsigned int* data, unsigned int length,
 }
 
 inline void __processUTF8Head(char u, unsigned int& s, int& status) {
-    unsigned char n;
+    unsigned char n = '\0';
     if((u&0x80) == 0x00) n = u;
     else if((u&0xE0) == 0xC0) {
         if((n = u&0x1F) < 0x02)  status = UTF8_FAIL;

--- a/Sockets/Source/Sockets.cpp
+++ b/Sockets/Source/Sockets.cpp
@@ -316,11 +316,13 @@ throw(SOC_EXCEPTION) {
         ss << "keepalive flag";
         goto KEEPALIVE_ERROR;
     }
+#ifndef __APPLE__
     if (setsockopt(handle.descriptor, IPPROTO_TCP, TCP_KEEPIDLE,
 		(const char*)&options.idle, sizeof(int)) < 0) {
         ss << "idle value";
         goto KEEPALIVE_ERROR;
     }
+#endif
     if (setsockopt(handle.descriptor, IPPROTO_TCP, TCP_KEEPINTVL,
         (const char*)&options.interval, sizeof(int)) < 0) {
         ss << "interval value";

--- a/Sockets/Source/Websocket.cpp
+++ b/Sockets/Source/Websocket.cpp
@@ -311,7 +311,7 @@ void Websocket::close(unsigned int code, std::string reason) {
 
 
 void Websocket::whenReadDone(char*& nextBuffer, int& nextLength) {
-    switch(_readState_) {
+    switch(+_readState_) {
     case 0: state2ByteHeader(nextBuffer, nextLength); break;
     case 1: stateExtendedHeader(nextBuffer, nextLength); break;
     case 2: stateBody(nextBuffer, nextLength); break;


### PR DESCRIPTION
These allow for the ImpactSockets to compile on mac and also fix an endianness bug found in the payload size that is transmitted as part of the RFC6455 protocol.