### PR TITLE
Feature: Default Route

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Cross-Platform C++ Sockets
 
 [![progress](https://img.shields.io/badge/OSX-pass-green.svg)]()&nbsp;
-[![progress](https://img.shields.io/badge/Win32-pass-green.svg)]()&nbsp;
+[![progress](https://img.shields.io/badge/Win32-fail-red.svg)]()&nbsp;
 [![progress](https://img.shields.io/badge/Debian-pass-green.svg)]()
 
 Tested on:<br>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![progress](https://img.shields.io/badge/OSX-pass-green.svg)]()&nbsp;
 [![progress](https://img.shields.io/badge/Win32-pass-green.svg)]()&nbsp;
-[![progress](https://img.shields.io/badge/Debian-unknown-yellow.svg)]()
+[![progress](https://img.shields.io/badge/Debian-pass-green.svg)]()
 
 Tested on:<br>
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 
 # Cross-Platform C++ Sockets
 
-[![progress](https://img.shields.io/badge/OSX-unknown-yellow.svg)]()&nbsp;
-[![progress](https://img.shields.io/badge/Win32-pass-gree.svg)]()&nbsp;
+[![progress](https://img.shields.io/badge/OSX-pass-green.svg)]()&nbsp;
+[![progress](https://img.shields.io/badge/Win32-pass-green.svg)]()&nbsp;
 [![progress](https://img.shields.io/badge/Debian-unknown-yellow.svg)]()
 
 Tested on:<br>

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 
 # Cross-Platform C++ Sockets
 
-[![progress](https://img.shields.io/badge/OSX-pass-green.svg)]()&nbsp;
-[![progress](https://img.shields.io/badge/Win32-fail-red.svg)]()&nbsp;
-[![progress](https://img.shields.io/badge/Debian-pass-green.svg)]()
+[![progress](https://img.shields.io/badge/OSX-unknown-yellow.svg)]()&nbsp;
+[![progress](https://img.shields.io/badge/Win32-pass-gree.svg)]()&nbsp;
+[![progress](https://img.shields.io/badge/Debian-unknown-yellow.svg)]()
 
 Tested on:<br>
 

--- a/Sockets/Include/sockets/networking.h
+++ b/Sockets/Include/sockets/networking.h
@@ -47,9 +47,8 @@ namespace networking {
     
     typedef struct netroute {
         std::string name;
-        std::shared_ptr<struct sockaddr> source;
+		unsigned int iface_index;
         std::shared_ptr<struct sockaddr> gateway;
-        std::shared_ptr<struct sockaddr> destination;
     } NetRoute;
 
 

--- a/Sockets/Include/sockets/networking.h
+++ b/Sockets/Include/sockets/networking.h
@@ -34,7 +34,7 @@ namespace networking {
         std::string                      name;
         std::string                      friendly_name;
         interface_type                   type;
-		unsigned int                     index;
+		unsigned int                     iface_index;
         unsigned int                     flags;
         std::shared_ptr<struct sockaddr> address;
         std::shared_ptr<struct sockaddr> netmask;

--- a/Sockets/Include/sockets/networking.h
+++ b/Sockets/Include/sockets/networking.h
@@ -43,12 +43,22 @@ namespace networking {
         bool                             ipv6;
         netinterface();
     } NetworkInterface;
+    
+    
+    typedef struct netroute {
+        std::string name;
+        std::shared_ptr<struct sockaddr> source;
+        std::shared_ptr<struct sockaddr> gateway;
+        std::shared_ptr<struct sockaddr> destination;
+    } NetRoute;
 
 
     std::string sockaddr_to_string(const struct sockaddr* address);
 
 
     std::vector<struct netinterface> find_network_interfaces()
+        /* throw(impact_error) */;
+    struct netroute find_default_route()
         /* throw(impact_error) */;
 }}
 

--- a/Sockets/Include/sockets/networking.h
+++ b/Sockets/Include/sockets/networking.h
@@ -34,6 +34,7 @@ namespace networking {
         std::string                      name;
         std::string                      friendly_name;
         interface_type                   type;
+		unsigned int                     index;
         unsigned int                     flags;
         std::shared_ptr<struct sockaddr> address;
         std::shared_ptr<struct sockaddr> netmask;

--- a/Sockets/Include/sockets/types.h
+++ b/Sockets/Include/sockets/types.h
@@ -91,6 +91,7 @@ namespace impact {
         ISO         = AF_ISO,      // ISO protocols
         LINK        = AF_LINK,     // link layer interface
         SYSTEM      = AF_SYSTEM,   // kernel event messages
+        ROUTE       = AF_ROUTE,    // kernel routing tables
     #else /* linux */
         // see <bits/socket.h> for more address families
         UNIX        = AF_UNIX,     // local communication (AF_LOCAL)

--- a/Sockets/Include/sockets/types.h
+++ b/Sockets/Include/sockets/types.h
@@ -22,6 +22,7 @@
     #include <errno.h>
 #if defined(__OS_LINUX__)
     #include <linux/version.h>
+    #include <linux/netlink.h>
 #endif
 #endif
 
@@ -244,7 +245,7 @@ namespace impact {
         // APES          = IPPROTO_APES,     /* Any Private Encryption Scheme */
         // GMTP          = IPPROTO_GMTP,     /* Graphical Media Transfer Protocol */
         // IPCOMP        = IPPROTO_IPCOMP,   /* Payload Compression (IPComp) */
-    #else /* linux */
+    #else /* __OS_LINUX__ */
         // IPIP          = IPPROT_IPIP,      /*m IPIP tunnels */
         // TP            = IPPROT_TP,        /*m SO Transport Protocol Class 4 */
         // DCCP          = IPPROT_DCCP,      /* Datagram Congestion Control Protocol */
@@ -257,6 +258,7 @@ namespace impact {
         // UDPLITE       = IPPROT_UDPLITE,   /* UDP-Lite Protocol */
         // MPLS          = IPPROT_MPLS,      /* Multi-Protocol Label Switching in IP */
         // IPV6_MH       = IPPROT_MH,        /* IPv6 Mobility Header */
+        ROUTE         = NETLINK_ROUTE,    /* Receives routing and link updates */
     #endif
     } SocketProtocol, InternetProtocol;
 

--- a/Sockets/Source/generic.cpp
+++ b/Sockets/Source/generic.cpp
@@ -170,6 +170,14 @@ internal::win_error_message(unsigned long __code)
             "operation.";
     case ERROR_NO_DATA:
         return "No addresses were found for the requested parameters.";
+	case ERROR_INSUFFICIENT_BUFFER:
+		return "The buffer pointed to by the pIpForwardTable parameter is not large "
+			"enough. The required size is returned in the DWORD variable pointed to "
+			"by the pdwSize parameter.";
+	case ERROR_NOT_SUPPORTED:
+		return "This function is not supported on the operating system in use on the "
+			"local system. This error is returned if there is no IP stack installed "
+			"on the local computer.";
     default:
         std::string data(128, '\0');
 

--- a/Sockets/Source/networking.cpp
+++ b/Sockets/Source/networking.cpp
@@ -312,12 +312,12 @@ internal::traverse_unicast(
 		if (socket_address->sa_family == AF_INET) {
 			set_ipv4_interface(socket_address,
 				address->OnLinkPrefixLength, &token);
-			token.index = __index[0];
+			token.iface_index = __index[0];
 		}
 		else if (socket_address->sa_family == AF_INET6) {
 			set_ipv6_interface(socket_address,
 				address->OnLinkPrefixLength, &token);
-			token.index = __index[1];
+			token.iface_index = __index[1];
 		}
         // don't add link interfaces to interface list
         else if (socket_address->sa_family == AF_LINK) continue;
@@ -497,7 +497,7 @@ internal::traverse_links(
 
         token.name          = std::string(target->ifa_name);
         token.friendly_name = token.name;
-        token.index         = if_nametoindex(target->ifa_name);
+        token.iface_index   = if_nametoindex(target->ifa_name);
         token.flags         = target->ifa_flags;
 
         token.address       = copy_sockaddr_to_ptr(target->ifa_addr);

--- a/Sockets/Source/networking.cpp
+++ b/Sockets/Source/networking.cpp
@@ -495,9 +495,10 @@ internal::traverse_links(
     for (auto target = __addresses; target != NULL; target = target->ifa_next) {
         netinterface token;
 
-        token.flags         = target->ifa_flags;
         token.name          = std::string(target->ifa_name);
         token.friendly_name = token.name;
+        token.index         = if_nametoindex(target->ifa_name);
+        token.flags         = target->ifa_flags;
 
         token.address       = copy_sockaddr_to_ptr(target->ifa_addr);
         token.netmask       = copy_sockaddr_to_ptr(target->ifa_netmask);

--- a/Sockets/Source/networking.cpp
+++ b/Sockets/Source/networking.cpp
@@ -271,7 +271,7 @@ internal::traverse_adapters(
         token.friendly_name = to_narrow_string(adapter->FriendlyName);
         token.type          = get_interface_type(adapter->IfType);
         token.flags         = (unsigned int)adapter->Flags;
-		token.index         = (unsigned int)adapter->IfIndex;
+		token.iface_index   = (unsigned int)adapter->IfIndex;
 
         if (adapter->PhysicalAddressLength != 0) {
             token.mac.resize(adapter->PhysicalAddressLength);

--- a/Tests/System/test_networking.cpp
+++ b/Tests/System/test_networking.cpp
@@ -15,7 +15,7 @@ print_interfaces(const std::vector<netinterface>& list)
     for (const auto& iface : list) {
         VERBOSE("Name:      " << iface.name);
 		VERBOSE("Friendly:  " << iface.friendly_name);
-		VERBOSE("Index:     " << iface.index);
+		VERBOSE("Index:     " << iface.iface_index);
         VERBOSE("Address:   " << networking::sockaddr_to_string(iface.address.get()));
         VERBOSE("Netmask:   " << networking::sockaddr_to_string(iface.netmask.get()));
         VERBOSE("Broadcast: " << networking::sockaddr_to_string(iface.broadcast.get()));

--- a/Tests/System/test_networking.cpp
+++ b/Tests/System/test_networking.cpp
@@ -9,7 +9,9 @@
 using namespace impact;
 using namespace networking;
 
-void print_interfaces(const std::vector<netinterface>& list) {
+void
+print_interfaces(const std::vector<netinterface>& list)
+{
     for (const auto& iface : list) {
         VERBOSE("Name:      " << iface.name);
         VERBOSE("Address:   " << networking::sockaddr_to_string(iface.address.get()));
@@ -50,9 +52,11 @@ void print_interfaces(const std::vector<netinterface>& list) {
     }
 }
 
-int main() {
-    VERBOSE("- BEGIN NETWORKING TEST -");
 
+void
+test_find_network_interfaces()
+{
+    VERBOSE("[Testing] Find Network Interface");
     try {
         std::vector<netinterface> list =
             networking::find_network_interfaces();
@@ -64,6 +68,26 @@ int main() {
     catch (...) {
         VERBOSE("Unexpected error");
     }
+}
+
+
+void
+test_find_default_route()
+{
+    VERBOSE("[Testing] Find Default Route");
+    struct netroute route = networking::find_default_route();
+    VERBOSE("Interface Name: " << route.name);
+    VERBOSE("Source:         " << networking::sockaddr_to_string(route.source.get()));
+    VERBOSE("Gateway:        " << networking::sockaddr_to_string(route.gateway.get()));
+    VERBOSE("Destination:    " << networking::sockaddr_to_string(route.destination.get()));
+}
+
+
+int main() {
+    VERBOSE("- BEGIN NETWORKING TEST -");
+
+    // test_find_network_interfaces();
+    test_find_default_route();
 
     VERBOSE("- END OF LINE -");
     return 0;

--- a/Tests/System/test_networking.cpp
+++ b/Tests/System/test_networking.cpp
@@ -14,6 +14,8 @@ print_interfaces(const std::vector<netinterface>& list)
 {
     for (const auto& iface : list) {
         VERBOSE("Name:      " << iface.name);
+		VERBOSE("Friendly:  " << iface.friendly_name);
+		VERBOSE("Index:     " << iface.index);
         VERBOSE("Address:   " << networking::sockaddr_to_string(iface.address.get()));
         VERBOSE("Netmask:   " << networking::sockaddr_to_string(iface.netmask.get()));
         VERBOSE("Broadcast: " << networking::sockaddr_to_string(iface.broadcast.get()));
@@ -30,6 +32,7 @@ print_interfaces(const std::vector<netinterface>& list)
         VERBOSE(std::dec);
 
         VERBOSE("IPv4:      " << (iface.ipv4 ? "true" : "false"));
+		VERBOSE("IPv6:      " << (iface.ipv6 ? "true" : "false"));
 
         switch (iface.type) {
         case interface_type::OTHER:
@@ -85,7 +88,7 @@ test_find_default_route()
 int main() {
     VERBOSE("- BEGIN NETWORKING TEST -");
 
-    // test_find_network_interfaces();
+    test_find_network_interfaces();
     test_find_default_route();
 
     VERBOSE("- END OF LINE -");

--- a/Tests/System/test_networking.cpp
+++ b/Tests/System/test_networking.cpp
@@ -76,10 +76,9 @@ test_find_default_route()
 {
     VERBOSE("[Testing] Find Default Route");
     struct netroute route = networking::find_default_route();
-    VERBOSE("Interface Name: " << route.name);
-    VERBOSE("Source:         " << networking::sockaddr_to_string(route.source.get()));
-    VERBOSE("Gateway:        " << networking::sockaddr_to_string(route.gateway.get()));
-    VERBOSE("Destination:    " << networking::sockaddr_to_string(route.destination.get()));
+    VERBOSE("Interface Name:  " << route.name);
+	VERBOSE("Interface Index: " << route.iface_index);
+    VERBOSE("Gateway:         " << networking::sockaddr_to_string(route.gateway.get()));
 }
 
 


### PR DESCRIPTION
- `find_default_route`, as the name implies, attempts to find the default route network packets are sent to. Typically this is the route from the computer to the local and global area networks (eg the internet).
- `iface_index` was added to `netinterface`. Unfortunately there is no direct way to get an IP address from the interface index alone. So, for the time being, the best way to get an IP address given a netroute is to loop through the list of netinterfaces and find the netinterface with a matching iface_index and address family.
- AF_LINKs are no longer included in the netinterface list on Windows.
